### PR TITLE
WIP: Combined FE/BE Lando Instance

### DIFF
--- a/README.template.md
+++ b/README.template.md
@@ -128,3 +128,19 @@ directly accept pull requests.
 Instead, to propose a change, please fork [pantheon-systems/decoupled-wordpress](https://github.com/pantheon-systems/decoupled-wordpress)
 and submit a PR to that repository.
 
+### Known Issues
+
+* When running Gatsby locally on an ARM based Mac using the NodeJS Lando Service,
+you may encounter errors related to the installing the Sharp Image Library. To
+resolve this issue, add the following to the `frontend` service in your
+`.lando.yml` file:
+
+```
+services:
+  frontend:
+    build_as_root:
+      - cd /tmp && wget https://github.com/libvips/libvips/releases/download/v8.11.4/vips-8.11.4.tar.gz && tar xf vips-8.11.4.tar.gz
+      - cd /tmp/vips-8.11.4 && ./configure && make && make install && ldconfig
+```
+
+This should install `libvps` which is required for the Sharp Image Library.

--- a/template.lando.yml
+++ b/template.lando.yml
@@ -17,8 +17,6 @@ services:
     type: node:14
     build:
       - "npm install --prefix ./frontend"
-    build_as_root:
-      - apt-get update -y && apt-get install -y libvips
     port: 8000
 
 tooling:


### PR DESCRIPTION
I'm working on creating a Terminus plugin to automate this, but in the meantime it would be helpful if you could run through the process manually to see if it resolves local environment issues you both have encountered recently. To set up manually:

* `brew install pantheon-systems/external/terminus`
* `terminus self:plugin:install terminus-build-tools-plugin`
* `composer clear-cache`
* Clone this repository into a directory called decoupled-wordpress
* Checkout this branch.
* Clone https://github.com/pantheon-systems/decoupled-wp-gatsby-frontend-demo into a subdirectory called `frontend`
* Within 'frontend' create a file .env.local with the following contents:
WPGRAPHQL_URL=http://decoupled-wordpress-demo.lndo.site/wp/graphql
* run `composer build-assets` in the root of the repository.
* run `lando start`
* View the BE site in a browser and install WordPress
* Run `lando npm run develop` to launch the Gatsby site in develop mode.