### PR TITLE
DB-2501: remove invalid filemount path which was breaking file uploads

### DIFF
--- a/pantheon.upstream.yml
+++ b/pantheon.upstream.yml
@@ -1,4 +1,3 @@
 api_version: 1
 web_docroot: true
 php_version: 7.3
-filemount: /app/uploads


### PR DESCRIPTION
This was really difficult to track down. It is possible to override the filemount path, which was necessary for the initial POC version of Pantheon's Bedrock project. When we incorporated changes from the most recent Pantheon Bedrock project, we forgot to remove this. 

I can't think of an easy way to test this locally, so I'm going to merge this so it can be tested.